### PR TITLE
Remove double-quotation marks from setvar values

### DIFF
--- a/SqlCmd.cs
+++ b/SqlCmd.cs
@@ -315,7 +315,21 @@ namespace com.rusanu.DBUtil {
 
 			Group valueGroup = m.Groups ["value"];
 			if (valueGroup.Success) {
-				Environment.Variables [variableGroup.Value] = valueGroup.Value;
+
+		                // Strip double quotations from beginning 
+		                string value = valueGroup.Value;
+		                if (value.StartsWith("\""))
+		                {
+		                    value = value.Substring(1);
+		                }
+		
+		                // Strip double quotations from end
+		                if (value.EndsWith("\""))
+		                {
+		                    value = value.Substring(0, value.Length - 1);
+		                }
+		
+				Environment.Variables [variableGroup.Value] = value;
 			} else {
 				Environment.Variables.Remove (variableGroup.Value);
 			}


### PR DESCRIPTION
Double quotation marks should not be considered as part of the value of a setvar statement. This is to make it compatible with the output from Microsoft SQL Server Data tooling.